### PR TITLE
Fix 404 when other locale's slug is different

### DIFF
--- a/localeredirector/services/LocaleRedirectorService.php
+++ b/localeredirector/services/LocaleRedirectorService.php
@@ -70,12 +70,14 @@ class LocaleRedirectorService extends BaseApplicationComponent
   private function newUrl($locale)
   {
     $qs = $this->querystring ? '?' . $this->querystring : '';
+    $segments = craft()->request->segments;
+    $lastSegment = end($segments);
     $criteria = craft()->elements->getCriteria(ElementType::Entry);
-    $criteria->slug = $this->path;
+    $criteria->slug = $lastSegment;
     $entry = $criteria->first();
     $new = craft()->elements->getElementById($entry->id, ElementType::Entry, $locale);
 
-    return UrlHelper::getSiteUrl($new->slug, null, null, $locale) . $qs;
+    return UrlHelper::getSiteUrl($new->uri, null, null, $locale) . $qs;
   }
 
   /**

--- a/localeredirector/services/LocaleRedirectorService.php
+++ b/localeredirector/services/LocaleRedirectorService.php
@@ -27,9 +27,11 @@ class LocaleRedirectorService extends BaseApplicationComponent
    */
   public function redirectToLocale($locale)
   {
-    $url = $this->newUrl($locale);
-    $this->setCookie('locale', $locale, time() + $this->expires);
-    craft()->request->redirect($url, true, 302);
+    if (strpos(craft()->request->getPath(), '.json') == false) {
+      $url = $this->newUrl($locale);
+      $this->setCookie('locale', $locale, time() + $this->expires);
+      craft()->request->redirect($url, true, 302);
+    }
   }
 
   /**

--- a/localeredirector/services/LocaleRedirectorService.php
+++ b/localeredirector/services/LocaleRedirectorService.php
@@ -29,8 +29,10 @@ class LocaleRedirectorService extends BaseApplicationComponent
   {
     if (strpos(craft()->request->getPath(), '.json') == false) {
       $url = $this->newUrl($locale);
-      $this->setCookie('locale', $locale, time() + $this->expires);
-      craft()->request->redirect($url, true, 302);
+      if ($url !== false) {
+        $this->setCookie('locale', $locale, time() + $this->expires);
+        craft()->request->redirect($url, true, 302);
+      }
     }
   }
 
@@ -77,9 +79,13 @@ class LocaleRedirectorService extends BaseApplicationComponent
     $criteria = craft()->elements->getCriteria(ElementType::Entry);
     $criteria->slug = $lastSegment;
     $entry = $criteria->first();
-    $new = craft()->elements->getElementById($entry->id, ElementType::Entry, $locale);
 
-    return UrlHelper::getSiteUrl($new->uri, null, null, $locale) . $qs;
+    if (!empty($entry)) {
+      $new = craft()->elements->getElementById($entry->id, ElementType::Entry, $locale);
+      return UrlHelper::getSiteUrl($new->uri, null, null, $locale) . $qs;
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/localeredirector/services/LocaleRedirectorService.php
+++ b/localeredirector/services/LocaleRedirectorService.php
@@ -70,8 +70,12 @@ class LocaleRedirectorService extends BaseApplicationComponent
   private function newUrl($locale)
   {
     $qs = $this->querystring ? '?' . $this->querystring : '';
+    $criteria = craft()->elements->getCriteria(ElementType::Entry);
+    $criteria->slug = $this->path;
+    $entry = $criteria->first();
+    $new = craft()->elements->getElementById($entry->id, ElementType::Entry, $locale);
 
-    return UrlHelper::getSiteUrl($this->path, null, null, $locale) . $qs;
+    return UrlHelper::getSiteUrl($new->slug, null, null, $locale) . $qs;
   }
 
   /**


### PR DESCRIPTION
Following the documentation example, this is working fine:

Requested URL: http://site.com/blog/article-title
Cookie Present: es
Configured Site Locales: en, fr, de, pt, es
Redirects To: http://site.com/es/blog/article-title

But if the slug of article-title is different in es locale (/titulo-del-articulo) , the user is redirected to a 404.

The plugin should probably constructs the new URL using original entry id, not using original path.